### PR TITLE
add ability to disconnect spotify account

### DIFF
--- a/backend/controllers/mainController.js
+++ b/backend/controllers/mainController.js
@@ -104,7 +104,7 @@ const sidebar = async (req, res) => {
             artistIds,
             trackIds
         );
-        console.log(threeRec);
+
         const resultObject = {
             pfp: pfp[1],
             nowPlaying: JSON.parse(nowPlaying),

--- a/backend/controllers/mainController.js
+++ b/backend/controllers/mainController.js
@@ -2,7 +2,7 @@ const {
     getNowPlaying,
     getUserProfile,
     getTop,
-    recommendThreeTracks
+    recommendThreeTracks,
 } = require('../services/spotify');
 const { getTopArtists } = require('../services/lastfm');
 const User = require('../models/userModel');
@@ -31,49 +31,46 @@ const profile = async (req, res) => {
     try {
         const user = await User.findOne({ username });
 
-        const [userProfile, topSongs, topArtists] = await Promise.all([
-            getUserProfile(user.access_token, user.refresh_token),
-            getTop(
-                user.access_token,
-                user.refresh_token,
-                'tracks',
-                10,
-                'long_term'
-            ),
-            getTop(
-                user.access_token,
-                user.refresh_token,
-                'artists',
-                10,
-                'long_term'
-            ),
-        ]);
+        if (user.access_token === undefined) {
+            const resultObject = { pfp: user.pfp };
+            res.status(200).json(resultObject);
+        } else {
+            const [topSongs, topArtists] = await Promise.all([
+                getTop(
+                    user.access_token,
+                    user.refresh_token,
+                    'tracks',
+                    10,
+                    'long_term'
+                ),
+                getTop(
+                    user.access_token,
+                    user.refresh_token,
+                    'artists',
+                    10,
+                    'long_term'
+                ),
+            ]);
 
-        user.pfp =
-            userProfile.images[0]?.url !== undefined
-                ? userProfile.images[0].url
-                : user.pfp;
+            const resultObject = {
+                pfp: user.pfp,
+                topSongs,
+                topArtists,
+            };
 
-        const resultObject = {
-            ...userProfile,
-            topSongs,
-            topArtists,
-        };
-
-        res.status(200).json(resultObject);
-        await user.save();
+            res.status(200).json(resultObject);
+            await user.save();
+        }
     } catch (err) {
         res.status(401).json({ error: 'User not connected to Spotify!' });
     }
 };
 
 const navbar = async (req, res) => {
-    const { username } = req.params;
+    const user = req.user;
 
     try {
-        const { pfp } = await User.findOne({ username });
-
-        res.status(200).json({ pfp });
+        res.status(200).json({ pfp: user.pfp[1] });
     } catch (err) {
         res.status(401).json({
             error: 'User has no affiliated profile picture!',
@@ -82,34 +79,40 @@ const navbar = async (req, res) => {
 };
 
 const sidebar = async (req, res) => {
-
     const { username } = req.params;
     try {
-        const { pfp, access_token, refresh_token} = await User.findOne({ username });
+        const { pfp, access_token, refresh_token, nowPlaying } =
+            await User.findOne({
+                username,
+            });
 
-        const [nowPlaying, topFive] = await Promise.all([
-            getNowPlaying(access_token, refresh_token),
-            getTop(
-                access_token,
-                refresh_token,
-                'tracks',
-                5,
-                'short_term'
-            ),
+        const [topFive] = await Promise.all([
+            getTop(access_token, refresh_token, 'tracks', 5, 'short_term'),
         ]);
 
-        const artistIds = topFive.items.slice(3, 5).map(item => item.artists[0].id).join('&3C')
-        const trackIds = topFive.items.slice(0, 3).map(item => item.artists[0].id).join('&3C')
-        const threeRec = await recommendThreeTracks(access_token, refresh_token, artistIds, trackIds)
+        const artistIds = topFive.items
+            .slice(3, 5)
+            .map((item) => item.artists[0].id)
+            .join('&3C');
+        const trackIds = topFive.items
+            .slice(0, 3)
+            .map((item) => item.artists[0].id)
+            .join('&3C');
+        const threeRec = await recommendThreeTracks(
+            access_token,
+            refresh_token,
+            artistIds,
+            trackIds
+        );
+        console.log(threeRec);
         const resultObject = {
-            pfp,
-            nowPlaying,
-            threeRec
+            pfp: pfp[1],
+            nowPlaying: JSON.parse(nowPlaying),
+            threeRec,
         };
-        console.log(resultObject)
+
         res.status(200).json(resultObject);
     } catch (err) {
-        console.log(err)
         res.status(401).json({
             error: 'User not connected to Spotify!',
         });
@@ -119,5 +122,5 @@ module.exports = {
     community,
     profile,
     navbar,
-    sidebar
+    sidebar,
 };

--- a/backend/controllers/userController.js
+++ b/backend/controllers/userController.js
@@ -1,4 +1,5 @@
 const User = require('../models/userModel');
+const { getUserProfile } = require('../services/spotify');
 const jwt = require('jsonwebtoken');
 
 const createToken = (_id) => {
@@ -50,19 +51,58 @@ const addToken = async (req, res) => {
     try {
         const { _id } = jwt.verify(token, process.env.SECRET);
 
+        const profile = await getUserProfile(access_token, refresh_token);
+
+        let pfp = [];
+        if (profile.images[0]?.url !== undefined) {
+            pfp = profile.images.map((image) => image.url);
+        }
+
         const user = await User.findOneAndUpdate(
             { _id },
-            { refresh_token, access_token },
+            { refresh_token, access_token, pfp },
             { returnNewDocument: true }
         );
 
-        const email = user.email;
+        const { username } = user;
         const idToken = createToken(user._id);
-        const spotifyToken = user.access_token ? true : false;
 
-        res.status(200).json({ email, idToken, spotifyToken });
+        res.status(200).json({ username, idToken, spotifyToken: true });
     } catch (error) {
         console.error(error);
+        res.status(401).json({ error: 'Request is not authorized' });
+    }
+};
+
+const removeToken = async (req, res) => {
+    const { authorization } = req.headers;
+    const { username, idToken } = req.body;
+
+    if (!authorization)
+        return res.status(401).json({ error: 'Authorization token required' });
+
+    const token = authorization.split(' ')[1];
+
+    try {
+        const { _id } = jwt.verify(token, process.env.SECRET);
+
+        await User.findOneAndUpdate(
+            { _id },
+            {
+                pfp: [
+                    'https://st3.depositphotos.com/6672868/13701/v/450/depositphotos_137014128-stock-illustration-user-profile-icon.jpg',
+                    'https://st3.depositphotos.com/6672868/13701/v/450/depositphotos_137014128-stock-illustration-user-profile-icon.jpg',
+                ],
+                $unset: {
+                    access_token: 1,
+                    refresh_token: 1,
+                    now_playing: 1,
+                },
+            }
+        );
+
+        res.status(200).json({ username, idToken, spotifyToken: false });
+    } catch (err) {
         res.status(401).json({ error: 'Request is not authorized' });
     }
 };
@@ -71,4 +111,5 @@ module.exports = {
     signupUser,
     loginUser,
     addToken,
+    removeToken,
 };

--- a/backend/models/userModel.js
+++ b/backend/models/userModel.js
@@ -35,11 +35,18 @@ const userSchema = new Schema({
     nowPlaying: {
         type: String,
     },
-    pfp: {
-        type: String,
-        default:
-            'https://static.vecteezy.com/system/resources/thumbnails/019/879/186/small/user-icon-on-transparent-background-free-png.png',
-    },
+    pfp: [
+        {
+            type: String,
+            default:
+                'https://st3.depositphotos.com/6672868/13701/v/450/depositphotos_137014128-stock-illustration-user-profile-icon.jpg',
+        },
+        {
+            type: String,
+            default:
+                'https://st3.depositphotos.com/6672868/13701/v/450/depositphotos_137014128-stock-illustration-user-profile-icon.jpg',
+        },
+    ],
 });
 
 // static signup method

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -3,6 +3,7 @@ const {
     signupUser,
     loginUser,
     addToken,
+    removeToken,
 } = require('../controllers/userController');
 
 const router = express.Router();
@@ -15,5 +16,7 @@ router.post('/signup', signupUser);
 
 // update spotify token for user
 router.patch('/token', addToken);
+
+router.patch('/disconnectSpotify', removeToken);
 
 module.exports = router;

--- a/backend/services/spotify.js
+++ b/backend/services/spotify.js
@@ -26,7 +26,7 @@ const refreshToken = async (refresh_token) => {
 
     const token = response.access_token;
 
-    // await User.findOneAndUpdate({ refresh_token }, { access_token: token });
+    await User.findOneAndUpdate({ refresh_token }, { access_token: token });
     return token;
 };
 
@@ -130,24 +130,37 @@ const getUserProfile = async (token, refresh_token) => {
     }
 };
 
-const recommendThreeTracks = async (token, refresh_token, artistID, trackID) => {
-// use getTop to get the 5 top tracks. 3 tracks used for track id, 2 will grab artist id
-// takes 3 track ids, 2 artist ids
+const recommendThreeTracks = async (
+    token,
+    refresh_token,
+    artistID,
+    trackID
+) => {
+    // use getTop to get the 5 top tracks. 3 tracks used for track id, 2 will grab artist id
+    // takes 3 track ids, 2 artist ids
 
-    const response = await fetch(`https://api.spotify.com/v1/recommendations?limit=3&seed_artists=${artistID}&seed_tracks=${trackID}&target_popularity=50`, {
-        method: 'GET',
-        headers: {
-            Authorization: `Bearer ${token}`,
-        },
-    });
+    const response = await fetch(
+        `https://api.spotify.com/v1/recommendations?limit=3&seed_artists=${artistID}&seed_tracks=${trackID}&target_popularity=50`,
+        {
+            method: 'GET',
+            headers: {
+                Authorization: `Bearer ${token}`,
+            },
+        }
+    );
 
-    // console.log(response.headers)
+    console.log(response);
     if (response.status === 200) {
-        const r = await response.json(); 
+        const r = await response.json();
         return r.tracks;
     } else if (response.status === 401) {
         const refreshedToken = await refreshToken(refresh_token);
-        const recall = await recommendThreeTracks(refreshedToken, refresh_token, artistID, trackID);
+        const recall = await recommendThreeTracks(
+            refreshedToken,
+            refresh_token,
+            artistID,
+            trackID
+        );
         return recall;
     }
 };
@@ -185,5 +198,5 @@ module.exports = {
     getUserProfile,
     getNowPlaying,
     getRecentlyPlayed,
-    recommendThreeTracks
+    recommendThreeTracks,
 };

--- a/backend/services/spotify.js
+++ b/backend/services/spotify.js
@@ -149,7 +149,6 @@ const recommendThreeTracks = async (
         }
     );
 
-    console.log(response);
     if (response.status === 200) {
         const r = await response.json();
         return r.tracks;

--- a/frontend/rea-list/src/context/AuthContext.js
+++ b/frontend/rea-list/src/context/AuthContext.js
@@ -5,6 +5,7 @@ export const AuthContext = createContext();
 export const authReducer = (state, action) => {
     switch (action.type) {
         case 'LOGIN':
+        case 'DISCONNECT':
             return { user: action.payload };
         case 'LOGOUT':
             return { user: null };

--- a/frontend/rea-list/src/hooks/useLogin.js
+++ b/frontend/rea-list/src/hooks/useLogin.js
@@ -16,22 +16,24 @@ export const useLogin = () => {
         });
 
         // post to db
-        const response = await fetch(process.env.REACT_APP_BACKEND + 'api/users/login', {
-            method: 'POST',
-            credentials: 'include',
-            body: jsonPayload,
-            headers: {
-                'Content-Type': 'application/json',
-            },
-        });
+        const response = await fetch(
+            process.env.REACT_APP_BACKEND + 'api/users/login',
+            {
+                method: 'POST',
+                credentials: 'include',
+                body: jsonPayload,
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+            }
+        );
         const json = await response.json();
-        console.log('hiiiiiiii');
+
         if (!response.ok) {
             setIsLoading(false);
             setError(json.error);
         }
         if (response.ok) {
-            console.log('asdfasfsa');
             // save user to local storage
             localStorage.setItem('user', JSON.stringify(json));
             // update the auth context

--- a/frontend/rea-list/src/pages/Profile.js
+++ b/frontend/rea-list/src/pages/Profile.js
@@ -6,23 +6,22 @@ import '../styles/ProfilePageStyles.css';
 import { useLogout } from '../hooks/useLogout.js';
 import { useEffect, useState } from 'react';
 import { useAuthContext } from '../hooks/useAuthContext.js';
+import { useNavigate } from 'react-router-dom';
 
 const Profile = () => {
+    const navigate = useNavigate();
     const { logout } = useLogout();
     const { user, dispatch } = useAuthContext();
+    const [loggedIn, setLoggedIn] = useState(user.spotifyToken);
     const [pfp, setPfp] = useState(null);
     const [artists, setArtists] = useState([]);
     const [songs, setSongs] = useState([]);
     const [following, setFollowing] = useState([]);
     const [followers, setFollowers] = useState([]);
 
-    const handleClick = () => {
-        logout();
-    };
-
     const updateDB = async (data) => {
-        const response = await fetch(process.env.REACT_APP_BACKEND + 
-            'api/users/token',
+        const response = await fetch(
+            process.env.REACT_APP_BACKEND + 'api/users/token',
             {
                 method: 'PATCH',
                 body: JSON.stringify(data),
@@ -34,12 +33,37 @@ const Profile = () => {
         );
 
         const json = await response.json();
+
+        setLoggedIn(true);
+        localStorage.setItem('user', JSON.stringify(json));
         dispatch({ type: 'LOGIN', payload: json });
+        navigate('/profile');
+    };
+
+    const disconnectSpotify = async () => {
+        const data = { username: user.username, idToken: user.idToken };
+        const response = await fetch(
+            process.env.REACT_APP_BACKEND + 'api/users/disconnectSpotify',
+            {
+                method: 'PATCH',
+                body: JSON.stringify(data),
+                headers: {
+                    Authorization: `Bearer ${user.idToken}`,
+                    'Content-Type': 'application/json',
+                },
+            }
+        );
+
+        const json = await response.json();
+
+        setLoggedIn(false);
+        localStorage.setItem('user', JSON.stringify(json));
+        dispatch({ type: 'DISCONNECT', payload: json });
     };
 
     const fetchProfile = async () => {
-        const response = await fetch(process.env.REACT_APP_BACKEND + 
-            'api/main/profile/' + user.username,
+        const response = await fetch(
+            process.env.REACT_APP_BACKEND + 'api/main/profile/' + user.username,
             {
                 method: 'GET',
                 headers: {
@@ -50,12 +74,13 @@ const Profile = () => {
         );
 
         const json = await response.json();
+        setPfp(json.pfp[1]);
 
-        setPfp(json.images[1].url);
-        setArtists(json.topArtists.items);
-        setSongs(json.topSongs.items);
+        if (json.topArtists !== undefined) {
+            setArtists(json.topArtists.items);
+            setSongs(json.topSongs.items);
+        }
     };
-
 
     useEffect(() => {
         // Extract the query value from the URL
@@ -64,32 +89,37 @@ const Profile = () => {
         const access_token = decipher.get('access_token');
         const refresh_token = decipher.get('refresh_token');
         const data = { access_token, refresh_token };
-        
+
         if (data.access_token !== null && !user.spotifyToken) updateDB(data);
 
-        if (pfp === null) {
-            fetchProfile();
-        }
-    });
+        fetchProfile();
+    }, []);
 
     return (
         <>
-            <ProfileNavbar/>
+            <ProfileNavbar />
 
-            <div className='profile-contents'>
+            <div className="profile-contents">
                 <UserHead pfp={pfp} username={user.username} />
                 <div className="logout">
-                    <button className="LogoutButton" onClick={handleClick}>
+                    <button className="LogoutButton" onClick={logout}>
                         Log Out
                     </button>
-                    {!user.spotifyToken ? (
-                        <a href={`${process.env.REACT_APP_BACKEND}api/spotify/auth`}>
+                    {!loggedIn ? (
+                        <a
+                            href={`${process.env.REACT_APP_BACKEND}api/spotify/auth`}
+                        >
                             <button className="SpotifyConnect">
                                 Connect to Spotify
                             </button>
                         </a>
                     ) : (
-                        <button className="SpotifyConnect">Connected!</button>
+                        <button
+                            className="SpotifyConnect"
+                            onClick={disconnectSpotify}
+                        >
+                            Disconnect Spotify
+                        </button>
                     )}
                 </div>
 

--- a/frontend/rea-list/src/templates/Navbar.js
+++ b/frontend/rea-list/src/templates/Navbar.js
@@ -73,8 +73,8 @@ const Navbar = ({
     };
 
     const fetchPfp = async () => {
-        const response = await fetch(process.env.REACT_APP_BACKEND + 
-            'api/main/navbar/' + user.username,
+        const response = await fetch(
+            process.env.REACT_APP_BACKEND + 'api/main/navbar/' + user.username,
             {
                 method: 'GET',
                 headers: {

--- a/frontend/rea-list/src/templates/SideBar.js
+++ b/frontend/rea-list/src/templates/SideBar.js
@@ -8,14 +8,15 @@ import { useEffect } from 'react';
 const SideBar = ({ isSidebarClicked }) => {
     const { user } = useAuthContext();
     const [error, setError] = useState(null);
-    const [userProfile, setUserProfile] = useState(null)
-    const [currentSong, setCurrentSong] = useState(null)
-    const [recSongs, setRecSongs] = useState([])
-    
+    const [userProfile, setUserProfile] = useState(
+        'https://st3.depositphotos.com/6672868/13701/v/450/depositphotos_137014128-stock-illustration-user-profile-icon.jpg'
+    );
+    const [currentSong, setCurrentSong] = useState(undefined);
+    const [recSongs, setRecSongs] = useState([]);
 
     const fetchProfile = async () => {
-        const response = await fetch(process.env.REACT_APP_BACKEND + 
-            'api/main/sidebar/' + user.username,
+        const response = await fetch(
+            process.env.REACT_APP_BACKEND + 'api/main/sidebar/' + user.username,
             {
                 method: 'GET',
                 headers: {
@@ -27,17 +28,15 @@ const SideBar = ({ isSidebarClicked }) => {
 
         // Gets users current song info
         const json = await response.json();
-        setRecSongs(json.threeRec.map((track) => (track.id)));
-        // setUserProfile(json.pfp)
-        setCurrentSong(json.nowPlaying)   
-        
-         
-
+        if (json.threeRec !== undefined)
+            setRecSongs(json.threeRec.map((track) => track.id));
+        setUserProfile(json.pfp);
+        setCurrentSong(json.nowPlaying);
     };
 
-    useEffect(()=> {
-        fetchProfile(); 
-    },[])
+    useEffect(() => {
+        if (user.spotifyToken) fetchProfile();
+    }, []);
 
     return (
         <div className="resize-handle">
@@ -46,48 +45,67 @@ const SideBar = ({ isSidebarClicked }) => {
                     <div className="profile-icon">
                         <img
                             className="listening-album-cover"
-                            src="https://media.pitchfork.com/photos/5929c43cea9e61561daa80db/master/pass/a240bddc.jpg"
+                            src={
+                                currentSong?.item?.album?.images !== undefined
+                                    ? currentSong.item.album.images[0].url
+                                    : 'https://media.pitchfork.com/photos/5929c43cea9e61561daa80db/master/pass/a240bddc.jpg'
+                            }
                             alt=""
                         />
-                        <SecondProfileIcon profile={"https://i.scdn.co/image/ab67706c0000da842a6199fd8dcd31ca3eadfd17"}/>
+                        <SecondProfileIcon profile={userProfile} />
                     </div>
 
                     <div className="information-container">
-                        <div className='current-song-info'>
-                            <h1 className='current-song-info-text'>Listening to:</h1>
-                            <h2 className='current-song-info-text'>Song Name</h2>
-                            <h2 className='current-song-info-text'>Artist</h2>
+                        <div className="current-song-info">
+                            <h1 className="current-song-info-text">
+                                Listening to:
+                            </h1>
+                            <h2 className="current-song-info-text">
+                                {currentSong?.item?.name !== undefined
+                                    ? currentSong.item.name
+                                    : 'Song Name'}
+                            </h2>
+                            <h2 className="current-song-info-text">
+                                {currentSong?.item?.artists !== undefined
+                                    ? currentSong.item.artists.map(
+                                          (artist) => artist.name
+                                      )
+                                    : 'Artist'}
+                            </h2>
                         </div>
-                        
-                        
-                        <div className='recommended-song'>
-                            <h3 className='recommended-song-text'> songs for you </h3>
-                            <iframe style={{border:12, height:80}} 
-                                    src={`https://open.spotify.com/embed/track/${recSongs[0]}`}
-                                    width="80%" 
-                                    height="100%"  
-                                    allowfullscreen="" 
-                                    allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" 
-                                    loading="lazy">
-                            </iframe>
-                            <iframe style={{border:12, height:80}} 
-                                    src={`https://open.spotify.com/embed/track/${recSongs[1]}`} 
-                                    width="80%" 
-                                    height="100%"  
-                                    allowfullscreen="" 
-                                    allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" 
-                                    loading="lazy">
-                            </iframe>
-                            <iframe style={{border:12, height:80}} 
-                                    src={`https://open.spotify.com/embed/track/${recSongs[2]}`} 
-                                    width="80%" 
-                                    height="100%"  
-                                    allowfullscreen="" 
-                                    allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" 
-                                    loading="lazy">
-                            </iframe>
-                           
-                            
+
+                        <div className="recommended-song">
+                            <h3 className="recommended-song-text">
+                                {' '}
+                                songs for you{' '}
+                            </h3>
+                            <iframe
+                                style={{ border: 12, height: 80 }}
+                                src={`https://open.spotify.com/embed/track/${recSongs[0]}`}
+                                width="80%"
+                                height="100%"
+                                allowfullscreen=""
+                                allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
+                                loading="lazy"
+                            ></iframe>
+                            <iframe
+                                style={{ border: 12, height: 80 }}
+                                src={`https://open.spotify.com/embed/track/${recSongs[1]}`}
+                                width="80%"
+                                height="100%"
+                                allowfullscreen=""
+                                allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
+                                loading="lazy"
+                            ></iframe>
+                            <iframe
+                                style={{ border: 12, height: 80 }}
+                                src={`https://open.spotify.com/embed/track/${recSongs[2]}`}
+                                width="80%"
+                                height="100%"
+                                allowfullscreen=""
+                                allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
+                                loading="lazy"
+                            ></iframe>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
previously, after users connected their spotify account, the button they clicked would update to say connected and nothing else. now they are able to use the same button to disconnect their account. doing so removes their token from cache and the database, but they are still required to manually go into their account settings (on spotify) to revoke total access.